### PR TITLE
feat(order-service): create OrderRepository with basic persistence tests

### DIFF
--- a/order-service/src/main/java/br/com/f2e/orderservice/domain/Order.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/domain/Order.java
@@ -3,6 +3,8 @@ package br.com.f2e.orderservice.domain;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
@@ -24,6 +26,7 @@ public class Order {
     @UuidGenerator
     private UUID id;
 
+    @Enumerated(EnumType.STRING)
     private OrderStatus orderStatus;
 
     private UUID customerId;

--- a/order-service/src/main/java/br/com/f2e/orderservice/repository/OrderRepository.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package br.com.f2e.orderservice.repository;
+
+import br.com.f2e.orderservice.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface OrderRepository extends JpaRepository<Order, UUID> { }

--- a/order-service/src/test/java/br/com/f2e/orderservice/repository/OrderRepositoryTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/repository/OrderRepositoryTest.java
@@ -1,0 +1,51 @@
+package br.com.f2e.orderservice.repository;
+
+import br.com.f2e.orderservice.domain.Order;
+import br.com.f2e.orderservice.domain.OrderItem;
+import br.com.f2e.orderservice.domain.OrderStatus;
+import br.com.f2e.orderservice.domain.ShippingAddress;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DataJpaTest
+public class OrderRepositoryTest {
+
+    private static final UUID CUSTOMER_ID = UUID.randomUUID();
+    private static final String CUSTOMER_EMAIL = "customer-email@outlook.com";
+
+    @Autowired
+    private OrderRepository repository;
+
+    @Test
+    void shouldPersistAnOrderInTheDatabase() {
+
+        var order = new Order(CUSTOMER_ID,CUSTOMER_EMAIL,getShippingAddress(),getItems());
+        var savedOrder = repository.save(order);
+        assertEquals(2,savedOrder.getItems().size());
+    }
+
+    @Test
+    void shouldRetrievePersistedOrderFromTheDataBase() {
+        var order = repository.findById(UUID.fromString("11111111-1111-1111-1111-111111111111")).orElseThrow(EntityNotFoundException::new);
+        assertEquals(OrderStatus.PAID, order.getStatus());
+    }
+
+    private ShippingAddress getShippingAddress() {
+        return new ShippingAddress("Street", "City", "State", "12345", "Country");
+    }
+
+    private List<OrderItem> getItems() {
+        return List.of(
+                new OrderItem(UUID.randomUUID(), "Product A", new BigDecimal("10.00"), 2),
+                new OrderItem(UUID.randomUUID(), "Product B", new BigDecimal("5.50"), 1)
+        );
+    }
+}

--- a/order-service/src/test/resources/application.yml
+++ b/order-service/src/test/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL
     driver-class-name: org.h2.Driver
     username: sa
     password:
@@ -10,8 +10,12 @@ spring:
       path: /h2-console
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
   liquibase:
     enabled: false
+  sql:
+    init:
+      mode: always

--- a/order-service/src/test/resources/data.sql
+++ b/order-service/src/test/resources/data.sql
@@ -1,0 +1,10 @@
+INSERT INTO orders (id, order_status, customer_id, mail,
+                    street, city, state, number, country)
+VALUES
+    ('11111111-1111-1111-1111-111111111111', 'PAID', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'customer1@example.com',
+     'Main St', 'Springfield', 'IL', '123', 'USA');
+
+INSERT INTO order_item (id, quantity, product_id, product_name, price, order_id)
+VALUES
+    ('22222222-2222-2222-2222-222222222222', 2, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Product A', 19.99, '11111111-1111-1111-1111-111111111111'),
+    ('33333333-3333-3333-3333-333333333333', 1, 'cccccccc-cccc-cccc-cccc-cccccccccccc', 'Product B', 39.99, '11111111-1111-1111-1111-111111111111');


### PR DESCRIPTION
- Added OrderRepository for data access using Spring Data JPA
- Implemented integration tests to ensure orders can be saved and retrieved successfully
- Added data.sql to create an order for testing purposes

Closes #13