### PR TITLE
14 order service expose rest api

### DIFF
--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
@@ -1,0 +1,4 @@
+package br.com.f2e.orderservice.controller;
+
+public class OrderController {
+}

--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
@@ -1,4 +1,41 @@
 package br.com.f2e.orderservice.controller;
 
+import br.com.f2e.orderservice.controller.dto.OrderRequest;
+import br.com.f2e.orderservice.controller.dto.OrderResponse;
+import br.com.f2e.orderservice.service.OrderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/orders")
 public class OrderController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OrderController.class);
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping
+    public ResponseEntity<OrderResponse> create(@RequestBody OrderRequest orderRequest) {
+        try {
+            OrderResponse orderResponse = orderService.create(orderRequest);
+            URI uri = URI.create("/orders/" + orderResponse.id());
+            return ResponseEntity.created(uri).body(orderResponse);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.error("Something went wrong {}", ex.getMessage(), ex);
+            return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            LOGGER.error("System error {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
 }

--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
@@ -3,15 +3,19 @@ package br.com.f2e.orderservice.controller;
 import br.com.f2e.orderservice.controller.dto.OrderRequest;
 import br.com.f2e.orderservice.controller.dto.OrderResponse;
 import br.com.f2e.orderservice.service.OrderService;
+import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/orders")
@@ -33,6 +37,19 @@ public class OrderController {
         } catch (IllegalArgumentException ex) {
             LOGGER.error("Something went wrong {}", ex.getMessage(), ex);
             return ResponseEntity.badRequest().build();
+        } catch (Exception e) {
+            LOGGER.error("System error {}", e.getMessage(), e);
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<OrderResponse> getById(@PathVariable UUID id) {
+        try {
+            return ResponseEntity.ok(orderService.findById(id));
+        } catch (EntityNotFoundException e) {
+            LOGGER.error("Order not found for id {}", id, e);
+            return ResponseEntity.notFound().build();
         } catch (Exception e) {
             LOGGER.error("System error {}", e.getMessage(), e);
             return ResponseEntity.internalServerError().build();

--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
@@ -4,6 +4,7 @@ import br.com.f2e.orderservice.controller.dto.OrderRequest;
 import br.com.f2e.orderservice.controller.dto.OrderResponse;
 import br.com.f2e.orderservice.service.OrderService;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +30,7 @@ public class OrderController {
     }
 
     @PostMapping
-    public ResponseEntity<OrderResponse> create(@RequestBody OrderRequest orderRequest) {
+    public ResponseEntity<OrderResponse> create(@RequestBody @Valid OrderRequest orderRequest) {
         try {
             OrderResponse orderResponse = orderService.create(orderRequest);
             URI uri = URI.create("/orders/" + orderResponse.id());

--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/dto/OrderItemRequest.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/dto/OrderItemRequest.java
@@ -1,11 +1,21 @@
 package br.com.f2e.orderservice.controller.dto;
 
 import br.com.f2e.orderservice.domain.OrderItem;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
 import java.util.UUID;
 
-public record OrderItemRequest(UUID productId, String productName, BigDecimal price, int quantity) {
+public record OrderItemRequest(@NotNull UUID productId,
+                               @NotEmpty String productName,
+                               @NotNull @DecimalMin(value = "0.0", inclusive = false)
+                               @Digits(integer = 10, fraction = 2)
+                               BigDecimal price,
+                               @Min(1) int quantity) {
 
     public OrderItem toEntity() {
         return new OrderItem(productId, productName, price, quantity);

--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/dto/OrderRequest.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/dto/OrderRequest.java
@@ -2,11 +2,15 @@ package br.com.f2e.orderservice.controller.dto;
 
 import br.com.f2e.orderservice.domain.Order;
 import br.com.f2e.orderservice.domain.ShippingAddress;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 import java.util.UUID;
 
-public record OrderRequest(UUID customerId, String email, ShippingAddress address, List<OrderItemRequest> itemsDto) {
+public record OrderRequest(@NotNull UUID customerId, @NotBlank String email, @NotNull ShippingAddress address,
+                           @NotNull @Size(min = 1) List<OrderItemRequest> itemsDto) {
 
     public Order toEntity() {
         var items = itemsDto.stream().map(OrderItemRequest::toEntity).toList();

--- a/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
@@ -73,9 +73,27 @@ class OrderControllerTest {
 
 
     @Test
-    void shouldReturnBadRequestWhenOrderRequestIsInvalid() throws Exception {
+    void shouldReturnBadRequestWhenOrderRequestHasNoItems() throws Exception {
 
         var orderRequest = new OrderRequest(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), Collections.emptyList());
+        var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
+        var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), items);
+
+        setOrderId(order, ORDER_ID);
+
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenOrderRequestWhenCustomerEmailIsNull() throws Exception {
+
+        var orderRequest = new OrderRequest(CUSTOMER_ID, null, getShippingAddress(),getItems());
         var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
         var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), items);
 

--- a/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
@@ -6,7 +6,6 @@ import br.com.f2e.orderservice.domain.Order;
 import br.com.f2e.orderservice.domain.ShippingAddress;
 import br.com.f2e.orderservice.repository.OrderRepository;
 import br.com.f2e.orderservice.service.OrderService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,11 +20,13 @@ import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -39,6 +40,7 @@ class OrderControllerTest {
     private static final UUID CUSTOMER_ID = UUID.randomUUID();
     private static final String CUSTOMER_EMAIL = "customer-email@outlook.com";
     private static final UUID ORDER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final String URI = "/orders";
 
     @Autowired
     private MockMvc mockMvc;
@@ -52,13 +54,13 @@ class OrderControllerTest {
 
         var orderRequest = new OrderRequest(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), getItems());
         var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
-        var order = new Order(CUSTOMER_ID,CUSTOMER_EMAIL,getShippingAddress(),items);
+        var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), items);
 
-        setOrderId(order,ORDER_ID);
+        setOrderId(order, ORDER_ID);
 
         when(orderRepository.save(any(Order.class))).thenReturn(order);
 
-        mockMvc.perform(post("/orders")
+        mockMvc.perform(post(URI)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(orderRequest))
                         .accept(MediaType.APPLICATION_JSON))
@@ -75,17 +77,33 @@ class OrderControllerTest {
 
         var orderRequest = new OrderRequest(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), Collections.emptyList());
         var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
-        var order = new Order(CUSTOMER_ID,CUSTOMER_EMAIL,getShippingAddress(),items);
+        var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), items);
 
-        setOrderId(order,ORDER_ID);
+        setOrderId(order, ORDER_ID);
 
         when(orderRepository.save(any(Order.class))).thenReturn(order);
 
-        mockMvc.perform(post("/orders")
+        mockMvc.perform(post(URI)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(orderRequest))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturnOrderDetailsGivenValidOrderId() throws Exception {
+
+        var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
+        var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), items);
+        setOrderId(order, ORDER_ID);
+
+        when(orderRepository.findById(ORDER_ID)).thenReturn(Optional.of(order));
+        mockMvc.perform(get(URI + "/" + ORDER_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(ORDER_ID.toString()))
+                .andExpect(jsonPath("$.totalItems").value(3))
+                .andExpect(jsonPath("$.totalValue").value(25.00));
     }
 
     private ShippingAddress getShippingAddress() {

--- a/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/controller/OrderControllerTest.java
@@ -1,0 +1,92 @@
+package br.com.f2e.orderservice.controller;
+
+import br.com.f2e.orderservice.controller.dto.OrderItemRequest;
+import br.com.f2e.orderservice.controller.dto.OrderRequest;
+import br.com.f2e.orderservice.domain.Order;
+import br.com.f2e.orderservice.domain.ShippingAddress;
+import br.com.f2e.orderservice.repository.OrderRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OrderController.class)
+@AutoConfigureMockMvc
+class OrderControllerTest {
+
+    private static final UUID CUSTOMER_ID = UUID.randomUUID();
+    private static final String CUSTOMER_EMAIL = "customer-email@outlook.com";
+    private static final UUID ORDER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Autowired
+    private MockMvc mockMvc;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @MockitoBean
+    private OrderRepository orderRepository;
+
+    @Test
+    void shouldCreateOrderSuccessfullyGivenValidRequest() throws Exception {
+
+        var orderRequest = new OrderRequest(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), getItems());
+        var items = getItems().stream().map(OrderItemRequest::toEntity).toList();
+        var order = new Order(CUSTOMER_ID,CUSTOMER_EMAIL,getShippingAddress(),items);
+
+        setOrderId(order,ORDER_ID);
+
+        when(orderRepository.save(any(Order.class))).thenReturn(order);
+
+        mockMvc.perform(post("/orders")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(orderRequest))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", containsString("/orders/" + ORDER_ID)))
+                .andExpect(jsonPath("$.id").value(ORDER_ID.toString()))
+                .andExpect(jsonPath("$.totalItems").value(3))
+                .andExpect(jsonPath("$.totalValue").value(25.00));
+    }
+
+
+    @Test
+    void shouldReturnBadRequestWhenOrderRequestIsInvalid() {
+
+    }
+
+    private ShippingAddress getShippingAddress() {
+        return new ShippingAddress("Street", "City", "State", "12345", "Country");
+    }
+
+    private List<OrderItemRequest> getItems() {
+        return List.of(
+                new OrderItemRequest(UUID.randomUUID(), "coca-cola", new BigDecimal("7.5"), 2),
+                new OrderItemRequest(UUID.randomUUID(), "ice cream", new BigDecimal("10"), 1));
+    }
+
+    private void setOrderId(Order order, UUID id) {
+        try {
+            Field field = Order.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(order, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/order-service/src/test/java/br/com/f2e/orderservice/service/OrderServiceTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/service/OrderServiceTest.java
@@ -43,7 +43,7 @@ class OrderServiceTest {
     @Test
     void shouldCreateOrderSuccessfullyGivenValidOrderRequest() {
         var orderRequest = new OrderRequest(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), getItems());
-        Order order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), getItems().stream().map(OrderItemRequest::toEntity).toList());
+        var order = new Order(CUSTOMER_ID, CUSTOMER_EMAIL, getShippingAddress(), getItems().stream().map(OrderItemRequest::toEntity).toList());
         when(orderRepository.save(any(Order.class)))
                 .thenReturn(order);
         var orderResponse = orderService.create(orderRequest);
@@ -96,5 +96,4 @@ class OrderServiceTest {
             throw new RuntimeException(e);
         }
     }
-
 }


### PR DESCRIPTION
# Implement OrderController with basic endpoints

This PR implements the `OrderController` with the following features:

- Created `POST /orders` endpoint to create new orders
- Created `GET /orders/{id}` endpoint to fetch an order by its ID
- Mapped DTOs to entities and entities back to DTOs for data transfer
- Added basic validation on DTOs for request integrity

These changes enable clients to create and retrieve orders via REST API.

## Related Issue

Closes #14
