### PR TITLE
refactor(order-service): centralize error handling

### DIFF
--- a/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/controller/OrderController.java
@@ -1,9 +1,8 @@
 package br.com.f2e.orderservice.controller;
 
-import br.com.f2e.orderservice.controller.dto.OrderRequest;
-import br.com.f2e.orderservice.controller.dto.OrderResponse;
+import br.com.f2e.orderservice.dto.OrderRequest;
+import br.com.f2e.orderservice.dto.OrderResponse;
 import br.com.f2e.orderservice.service.OrderService;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,29 +30,14 @@ public class OrderController {
 
     @PostMapping
     public ResponseEntity<OrderResponse> create(@RequestBody @Valid OrderRequest orderRequest) {
-        try {
-            OrderResponse orderResponse = orderService.create(orderRequest);
-            URI uri = URI.create("/orders/" + orderResponse.id());
-            return ResponseEntity.created(uri).body(orderResponse);
-        } catch (IllegalArgumentException ex) {
-            LOGGER.error("Something went wrong {}", ex.getMessage(), ex);
-            return ResponseEntity.badRequest().build();
-        } catch (Exception e) {
-            LOGGER.error("System error {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
-        }
+        LOGGER.info("creating order with request {}",orderRequest);
+        OrderResponse orderResponse = orderService.create(orderRequest);
+        URI uri = URI.create("/orders/" + orderResponse.id());
+        return ResponseEntity.created(uri).body(orderResponse);
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<OrderResponse> getById(@PathVariable UUID id) {
-        try {
-            return ResponseEntity.ok(orderService.findById(id));
-        } catch (EntityNotFoundException e) {
-            LOGGER.error("Order not found for id {}", id, e);
-            return ResponseEntity.notFound().build();
-        } catch (Exception e) {
-            LOGGER.error("System error {}", e.getMessage(), e);
-            return ResponseEntity.internalServerError().build();
-        }
+        return ResponseEntity.ok(orderService.findById(id));
     }
 }

--- a/order-service/src/main/java/br/com/f2e/orderservice/dto/ItemResponse.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/dto/ItemResponse.java
@@ -1,4 +1,4 @@
-package br.com.f2e.orderservice.controller.dto;
+package br.com.f2e.orderservice.dto;
 
 import br.com.f2e.orderservice.domain.OrderItem;
 

--- a/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderItemRequest.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderItemRequest.java
@@ -1,4 +1,4 @@
-package br.com.f2e.orderservice.controller.dto;
+package br.com.f2e.orderservice.dto;
 
 import br.com.f2e.orderservice.domain.OrderItem;
 import jakarta.validation.constraints.DecimalMin;

--- a/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderRequest.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderRequest.java
@@ -1,4 +1,4 @@
-package br.com.f2e.orderservice.controller.dto;
+package br.com.f2e.orderservice.dto;
 
 import br.com.f2e.orderservice.domain.Order;
 import br.com.f2e.orderservice.domain.ShippingAddress;

--- a/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderResponse.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/dto/OrderResponse.java
@@ -1,4 +1,4 @@
-package br.com.f2e.orderservice.controller.dto;
+package br.com.f2e.orderservice.dto;
 
 import br.com.f2e.orderservice.domain.Order;
 

--- a/order-service/src/main/java/br/com/f2e/orderservice/service/OrderService.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/service/OrderService.java
@@ -1,7 +1,7 @@
 package br.com.f2e.orderservice.service;
 
-import br.com.f2e.orderservice.controller.dto.OrderRequest;
-import br.com.f2e.orderservice.controller.dto.OrderResponse;
+import br.com.f2e.orderservice.dto.OrderRequest;
+import br.com.f2e.orderservice.dto.OrderResponse;
 import br.com.f2e.orderservice.repository.OrderRepository;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
@@ -23,6 +23,6 @@ public class OrderService {
     }
 
     public OrderResponse findById(UUID id) {
-        return repository.findById(id).map(OrderResponse::toDto).orElseThrow(EntityNotFoundException::new);
+        return repository.findById(id).map(OrderResponse::toDto).orElseThrow(() -> new EntityNotFoundException("Order not found for id " + id));
     }
 }

--- a/order-service/src/main/java/br/com/f2e/orderservice/web/advice/GlobalExceptionHandler.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/web/advice/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package br.com.f2e.orderservice.web.advice;
+
+import br.com.f2e.orderservice.web.advice.dto.ErrorResponse;
+import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException ex) {
+        LOGGER.error("Order not found", ex);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(ex.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<List<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        List<ErrorResponse> responses = ex.getBindingResult().getAllErrors()
+                .stream().map(error -> new ErrorResponse(error.getDefaultMessage())).toList();
+        LOGGER.error("Error list {}", responses);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responses);
+    }
+}

--- a/order-service/src/main/java/br/com/f2e/orderservice/web/advice/dto/ErrorResponse.java
+++ b/order-service/src/main/java/br/com/f2e/orderservice/web/advice/dto/ErrorResponse.java
@@ -1,0 +1,4 @@
+package br.com.f2e.orderservice.web.advice.dto;
+
+public record ErrorResponse(String message) {
+}

--- a/order-service/src/test/java/br/com/f2e/orderservice/service/OrderServiceTest.java
+++ b/order-service/src/test/java/br/com/f2e/orderservice/service/OrderServiceTest.java
@@ -1,9 +1,9 @@
 package br.com.f2e.orderservice.service;
 
-import br.com.f2e.orderservice.controller.dto.ItemResponse;
-import br.com.f2e.orderservice.controller.dto.OrderItemRequest;
-import br.com.f2e.orderservice.controller.dto.OrderRequest;
-import br.com.f2e.orderservice.controller.dto.OrderResponse;
+import br.com.f2e.orderservice.dto.ItemResponse;
+import br.com.f2e.orderservice.dto.OrderItemRequest;
+import br.com.f2e.orderservice.dto.OrderRequest;
+import br.com.f2e.orderservice.dto.OrderResponse;
 import br.com.f2e.orderservice.domain.Order;
 import br.com.f2e.orderservice.domain.OrderItem;
 import br.com.f2e.orderservice.domain.ShippingAddress;


### PR DESCRIPTION
### What was done

- Created a `ControllerAdvice` to centralize error handling across the `order-service`.
- Moved DTO classes from `controller/dto` to a shared `dto` package to allow usage in both controller and service layers.
- Updated existing tests to reflect the new DTO structure and validate the error handling logic.

### Why this is important

Centralizing error handling reduces boilerplate, improves consistency of error responses, and makes future maintenance easier. Moving DTOs clarifies their role across layers, following best practices of clean architecture.

---

Closes #15
