### PR TITLE
41 define relationships between entities

### DIFF
--- a/product-service/src/main/java/br/com/f2e/productservice/domain/Image.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/domain/Image.java
@@ -2,13 +2,21 @@ package br.com.f2e.productservice.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 
 @Entity
 public class Image extends BaseEntity {
 
     @Column(length = 200)
     private String altText;
+
     private boolean isMain;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     protected Image() {}
 

--- a/product-service/src/main/java/br/com/f2e/productservice/domain/Product.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/domain/Product.java
@@ -1,21 +1,43 @@
 package br.com.f2e.productservice.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 public class Product extends BaseEntity {
 
     @Column(length = 200)
     private String name;
+
     @Column(length = 300, nullable = false)
     private String description;
+
     @Column(precision = 10, scale = 2, nullable = false)
     private BigDecimal price;
+
     private int quantity;
     private boolean isActive = true;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "brand_id", nullable = false)
+    private Brand brand;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private final Set<Image> images = new HashSet<>();
 
     @SuppressWarnings("unused")
     protected Product() {}


### PR DESCRIPTION
## 🔗 Define Entity Relationships

This PR establishes the associations between core domain entities in the `product-service`, ensuring data integrity and proper navigation across related data models.

The relationships are mapped using JPA annotations such as `@ManyToOne` and `@OneToMany`, and follow best practices for relational modeling in a Spring Boot + JPA context.

---

## ✅ Relationships Defined

- **Product → Category**  
  - Many-to-one: each product belongs to a single category.
- **Product → Brand**  
  - Many-to-one: each product is associated with a single brand.
- **Product → Image**  
  - One-to-many: a product can have multiple images, with `orphanRemoval` enabled for consistency.

The `Image` entity contains a `product` reference as the owning side of the relationship.

---

## 🎯 Related Issue

Closes #41
