### PR TITLE
42 create category crud

### DIFF
--- a/init/02-create-order-db.sql
+++ b/init/02-create-order-db.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE orders;

--- a/product-service/src/main/java/br/com/f2e/productservice/controller/CategoryController.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/controller/CategoryController.java
@@ -1,0 +1,84 @@
+package br.com.f2e.productservice.controller;
+
+import br.com.f2e.productservice.dto.CategoryRequest;
+import br.com.f2e.productservice.dto.CategoryResponse;
+import br.com.f2e.productservice.service.CategoryService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/categories")
+public class CategoryController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CategoryController.class);
+
+    private final CategoryService service;
+
+    public CategoryController(CategoryService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<CategoryResponse> create(@Valid @RequestBody CategoryRequest request) {
+        LOGGER.info("create category body {}", request);
+
+        var categoryResponse = service.create(request);
+        return ResponseEntity.created(URI.create("categories/" + categoryResponse.id())).body(categoryResponse);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable UUID id, @RequestBody CategoryRequest request) {
+        LOGGER.info("update category id {}, body{}", id, request);
+        try {
+            service.update(id, request);
+            return ResponseEntity.noContent().build();
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoryResponse> findById(@PathVariable UUID id) {
+        try {
+            return ResponseEntity.ok(service.findById(id));
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CategoryResponse>> findAll() {
+        return ResponseEntity.ok(service.findAll());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        try {
+            service.delete(id);
+            return ResponseEntity.noContent().build();
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/domain/Category.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/domain/Category.java
@@ -19,4 +19,8 @@ public class Category extends BaseEntity {
         this.name = name;
         this.description = description;
     }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/product-service/src/main/java/br/com/f2e/productservice/dto/CategoryRequest.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/dto/CategoryRequest.java
@@ -1,0 +1,11 @@
+package br.com.f2e.productservice.dto;
+
+import br.com.f2e.productservice.domain.Category;
+import jakarta.validation.constraints.NotBlank;
+
+public record CategoryRequest(@NotBlank String name, String description) {
+
+    public Category toEntity() {
+        return new Category(name, description);
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/dto/CategoryResponse.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/dto/CategoryResponse.java
@@ -1,0 +1,13 @@
+package br.com.f2e.productservice.dto;
+
+import br.com.f2e.productservice.domain.Category;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record CategoryResponse(@NotBlank UUID id, @NotBlank String name) {
+
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(category.getId(), category.getName());
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/repository/CategoryRepository.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/repository/CategoryRepository.java
@@ -1,0 +1,18 @@
+package br.com.f2e.productservice.repository;
+
+import br.com.f2e.productservice.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, UUID> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Category c set c.name = :name, c.description = :description WHERE c.id = :id ")
+    int update(@Param("id") UUID id, @Param("name") String name, @Param("description") String description);
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/service/CategoryService.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/service/CategoryService.java
@@ -1,0 +1,53 @@
+package br.com.f2e.productservice.service;
+
+import br.com.f2e.productservice.dto.CategoryRequest;
+import br.com.f2e.productservice.dto.CategoryResponse;
+import br.com.f2e.productservice.repository.CategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class CategoryService {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(CategoryService.class);
+
+    private final CategoryRepository repository;
+
+    public CategoryService(CategoryRepository repository) {
+        this.repository = repository;
+    }
+
+    public CategoryResponse create(CategoryRequest request) {
+        LOGGER.info("Creating category {}", request);
+        return CategoryResponse.from(repository.save(request.toEntity()));
+    }
+
+    public void update(UUID id, CategoryRequest categoryRequest) {
+        LOGGER.info("updating category id {}, request {}", id, categoryRequest);
+        int updated = repository.update(id, categoryRequest.name(), categoryRequest.description());
+        if (updated == 0) {
+            LOGGER.error("Category not found for id {}", id);
+            throw new EntityNotFoundException("Category not found ");
+        }
+    }
+
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    public CategoryResponse findById(UUID id) {
+        return CategoryResponse.from(repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Category not found")));
+    }
+
+    public List<CategoryResponse> findAll() {
+        return repository.findAll()
+                .stream()
+                .map(CategoryResponse::from).toList();
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/service/CategoryService.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/service/CategoryService.java
@@ -4,6 +4,7 @@ import br.com.f2e.productservice.dto.CategoryRequest;
 import br.com.f2e.productservice.dto.CategoryResponse;
 import br.com.f2e.productservice.repository.CategoryRepository;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class CategoryService {
         return CategoryResponse.from(repository.save(request.toEntity()));
     }
 
+    @Transactional
     public void update(UUID id, CategoryRequest categoryRequest) {
         LOGGER.info("updating category id {}, request {}", id, categoryRequest);
         int updated = repository.update(id, categoryRequest.name(), categoryRequest.description());
@@ -36,6 +38,7 @@ public class CategoryService {
         }
     }
 
+    @Transactional
     public void delete(UUID id) {
         repository.deleteById(id);
     }

--- a/product-service/src/test/java/br/com/f2e/productservice/controller/CategoryControllerTest.java
+++ b/product-service/src/test/java/br/com/f2e/productservice/controller/CategoryControllerTest.java
@@ -1,0 +1,137 @@
+package br.com.f2e.productservice.controller;
+
+import br.com.f2e.productservice.domain.Category;
+import br.com.f2e.productservice.dto.CategoryRequest;
+import br.com.f2e.productservice.dto.CategoryResponse;
+import br.com.f2e.productservice.repository.CategoryRepository;
+import br.com.f2e.productservice.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@Testcontainers
+@AutoConfigureMockMvc
+class CategoryControllerTest {
+
+    private static final String URI = "/categories";
+
+    @Container
+    static final PostgreSQLContainer<?> postgresContainer = new PostgreSQLContainer<>("postgres:latest");
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @DynamicPropertySource
+    static void overrideProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgresContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", postgresContainer::getUsername);
+        registry.add("spring.datasource.password", postgresContainer::getPassword);
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldCreateCategorySuccessfullyGivenValidRequest() throws Exception {
+
+        var request = new CategoryRequest("Clothes", "Woman dresses");
+
+        MvcResult result = mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Clothes"))
+                .andReturn();
+
+        var category = JsonUtils.toObject(result.getResponse().getContentAsString(), CategoryResponse.class);
+        var location = result.getResponse().getHeader("Location");
+
+        assertNotNull(location, "Location header should not be null");
+        assertEquals("categories/" + category.id(), location);
+    }
+
+    @Test
+    void shouldUpdateCategorySuccessfullyGivenValidRequest() throws Exception {
+
+        var id = UUID.fromString("7114909f-a08e-4faf-b90c-a0602ce85f3f");
+        var request = new CategoryRequest("Whisky", "18 years Irish whisky ");
+
+        mockMvc.perform((put(URI + "/" + id, request))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+    @Test
+    void shouldRetrieveCategorySuccessfullyGivenValidId() throws Exception {
+
+        var id = UUID.fromString("80fa046f-4b11-4364-b5f4-31fc12267234");
+
+        mockMvc.perform(get(URI + "/" + id)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Software"))
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    void shouldDeleteCategorySuccessfullyGivenValidId() throws Exception {
+        Category category = categoryRepository.save(new Category("Test", "To test deletion method"));
+        mockMvc.perform(delete(URI + "/" + category.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenRetrievingNonExistingCategory() throws Exception {
+
+        var nonExistentId = UUID.randomUUID();
+
+        mockMvc.perform(get(URI + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUpdatingNonExistingCategory() throws Exception {
+
+        var nonExistentId = UUID.randomUUID();
+        var request = new CategoryRequest("Invalid", "Non-existent category");
+
+        mockMvc.perform(put(URI + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenCreatingCategoryWithInvalidData() throws Exception {
+
+        var invalidRequest = new CategoryRequest("", "Description without name");
+
+        mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/product-service/src/test/java/br/com/f2e/productservice/utils/JsonUtils.java
+++ b/product-service/src/test/java/br/com/f2e/productservice/utils/JsonUtils.java
@@ -1,0 +1,26 @@
+package br.com.f2e.productservice.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public static String toJson(Object object) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(object);
+        } catch (JsonProcessingException ex) {
+            throw new RuntimeException("Error serializing to JSON", ex);
+        }
+    }
+
+    public static <T> T toObject(String string, Class<T> tClass) {
+        try {
+        return OBJECT_MAPPER.readValue(string,tClass);
+
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## 📄 Description

This PR implements the full CRUD functionality for the `Category` entity. It includes the creation of DTOs, REST endpoints, service logic, and repository interface to manage product categories.

---

## ✅ What's Included

- **DTOs**
  - `CategoryRequest` for incoming data (create/update)
  - `CategoryResponse` for outgoing data

- **Controller**
  - `POST /categories` — create new category
  - `GET /categories` — list all categories
  - `GET /categories/{id}` — get a category by ID
  - `PUT /categories/{id}` — update a category
  - `DELETE /categories/{id}` — remove a category

- **Service Layer**
  - Encapsulates business logic and communicates with the repository

- **Repository**
  - `CategoryRepository` extends `JpaRepository`

- **Validation**
  - Basic validation annotations on `CategoryRequest`

- **Tests**
  - Basic integration tests for controller endpoints
