### PR TITLE
52 create brand crud

### DIFF
--- a/product-service/src/main/java/br/com/f2e/productservice/controller/BrandController.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/controller/BrandController.java
@@ -1,0 +1,83 @@
+package br.com.f2e.productservice.controller;
+
+import br.com.f2e.productservice.dto.BrandRequest;
+import br.com.f2e.productservice.dto.BrandResponse;
+import br.com.f2e.productservice.service.BrandService;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.validation.Valid;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/brands")
+public class BrandController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrandController.class);
+
+    private final BrandService service;
+
+    public BrandController(BrandService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<BrandResponse> create(@Valid @RequestBody BrandRequest request) {
+        LOGGER.info("create brand body {}", request);
+
+        var brandResponse = service.create(request);
+        return ResponseEntity.created(URI.create("brands/" + brandResponse.id())).body(brandResponse);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable UUID id, @RequestBody BrandRequest request) {
+        LOGGER.info("update brand id {}, body{}", id, request);
+        try {
+            service.update(id, request);
+            return ResponseEntity.noContent().build();
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<BrandResponse> findById(@PathVariable UUID id) {
+        try {
+            return ResponseEntity.ok(service.findById(id));
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+
+    @GetMapping
+    public ResponseEntity<List<BrandResponse>> findAll() {
+        return ResponseEntity.ok(service.findAll());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        try {
+            service.delete(id);
+            return ResponseEntity.noContent().build();
+        } catch (EntityNotFoundException ex) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/domain/Brand.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/domain/Brand.java
@@ -19,4 +19,13 @@ public class Brand extends BaseEntity {
         this.name = name;
         this.description = description;
     }
+
+    public void update(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/product-service/src/main/java/br/com/f2e/productservice/dto/BrandRequest.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/dto/BrandRequest.java
@@ -1,0 +1,11 @@
+package br.com.f2e.productservice.dto;
+
+import br.com.f2e.productservice.domain.Brand;
+import jakarta.validation.constraints.NotBlank;
+
+public record BrandRequest(@NotBlank String name, String description) {
+
+    public Brand toEntity() {
+        return new Brand(name, description);
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/dto/BrandResponse.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/dto/BrandResponse.java
@@ -1,0 +1,11 @@
+package br.com.f2e.productservice.dto;
+
+import br.com.f2e.productservice.domain.Brand;
+
+import java.util.UUID;
+
+public record BrandResponse(UUID id, String name) {
+    public static BrandResponse from(Brand brand) {
+        return new BrandResponse(brand.getId(),brand.getName());
+    }
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/repository/BrandRepository.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/repository/BrandRepository.java
@@ -1,0 +1,11 @@
+package br.com.f2e.productservice.repository;
+
+import br.com.f2e.productservice.domain.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface BrandRepository extends JpaRepository<Brand, UUID> {
+}

--- a/product-service/src/main/java/br/com/f2e/productservice/service/BrandService.java
+++ b/product-service/src/main/java/br/com/f2e/productservice/service/BrandService.java
@@ -1,0 +1,58 @@
+package br.com.f2e.productservice.service;
+
+import br.com.f2e.productservice.domain.Brand;
+import br.com.f2e.productservice.dto.BrandRequest;
+import br.com.f2e.productservice.dto.BrandResponse;
+import br.com.f2e.productservice.repository.BrandRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class BrandService {
+
+    private final static Logger LOGGER = LoggerFactory.getLogger(BrandService.class);
+
+    private final BrandRepository repository;
+
+    public BrandService(BrandRepository repository) {
+        this.repository = repository;
+    }
+
+    public BrandResponse create(BrandRequest request) {
+        LOGGER.info("Creating brand {}", request);
+        return BrandResponse.from(repository.save(request.toEntity()));
+    }
+
+    @Transactional
+    public void update(UUID id, BrandRequest brandRequest) {
+        LOGGER.info("updating brand id {}, request {}", id, brandRequest);
+
+        Brand brand = repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Brand not found"));
+
+        brand.update(brandRequest.name(), brandRequest.description());
+    }
+
+
+    @Transactional
+    public void delete(UUID id) {
+        repository.deleteById(id);
+    }
+
+    public BrandResponse findById(UUID id) {
+        return BrandResponse.from(repository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Brand not found")));
+    }
+
+    public List<BrandResponse> findAll() {
+        return repository.findAll()
+                .stream()
+                .map(BrandResponse::from).toList();
+    }
+}

--- a/product-service/src/test/java/br/com/f2e/productservice/controller/BrandControllerTest.java
+++ b/product-service/src/test/java/br/com/f2e/productservice/controller/BrandControllerTest.java
@@ -1,0 +1,121 @@
+package br.com.f2e.productservice.controller;
+
+import br.com.f2e.productservice.domain.Brand;
+import br.com.f2e.productservice.dto.BrandRequest;
+import br.com.f2e.productservice.dto.BrandResponse;
+import br.com.f2e.productservice.repository.BrandRepository;
+import br.com.f2e.productservice.utils.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class BrandControllerTest {
+
+    private static final String URI = "/brands";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private BrandRepository brandRepository;
+
+    @Test
+    void shouldCreateBrandSuccessfullyGivenValidRequest() throws Exception {
+
+        var request = new BrandRequest("Clothes", "Woman dresses");
+
+        MvcResult result = mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name").value("Clothes"))
+                .andReturn();
+
+        var brand = JsonUtils.toObject(result.getResponse().getContentAsString(), BrandResponse.class);
+        var location = result.getResponse().getHeader("Location");
+
+        assertNotNull(location, "Location header should not be null");
+        assertEquals("brands/" + brand.id(), location);
+    }
+
+    @Test
+    void shouldUpdateBrandSuccessfullyGivenValidRequest() throws Exception {
+
+        var id = UUID.fromString("de5fed5a-96fd-4e06-96e0-2e211c8318f5");
+        var request = new BrandRequest("Adidas", "Sportive clothes");
+
+        mockMvc.perform((put(URI + "/" + id, request))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+    @Test
+    void shouldRetrieveBrandSuccessfullyGivenValidId() throws Exception {
+
+        var id = UUID.fromString("bb98952e-1e99-48fd-9a0c-9a6d4b0d0f26");
+
+        mockMvc.perform(get(URI + "/" + id)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("Initech"))
+                .andExpect(jsonPath("$.id").value(id.toString()));
+    }
+
+    @Test
+    void shouldDeleteBrandSuccessfullyGivenValidId() throws Exception {
+        Brand brand = brandRepository.save(new Brand("Test", "To test deletion method"));
+        mockMvc.perform(delete(URI + "/" + brand.getId()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenRetrievingNonExistingBrand() throws Exception {
+
+        var nonExistentId = UUID.randomUUID();
+
+        mockMvc.perform(get(URI + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenUpdatingNonExistingBrand() throws Exception {
+
+        var nonExistentId = UUID.randomUUID();
+        var request = new BrandRequest("Invalid", "Non-existent brand");
+
+        mockMvc.perform(put(URI + "/" + nonExistentId)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(request)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenCreatingBrandWithInvalidData() throws Exception {
+
+        var invalidRequest = new BrandRequest("", "Description without name");
+
+        mockMvc.perform(post(URI)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(JsonUtils.toJson(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 📄 Description

This PR implements the full CRUD functionality for the `Brand` entity. It includes the creation of DTOs, REST endpoints, service logic, and repository interface to manage product brands.

---

## ✅ What's Included

- **DTOs**
  - `BrandRequest` for incoming data (create/update)
  - `BrandResponse` for outgoing data

- **Controller**
  - `POST /brands` — create new Brand
  - `GET /brands` — list all brands
  - `GET /brands/{id}` — get a Brand by ID
  - `PUT /brands/{id}` — update a Brand
  - `DELETE /brands/{id}` — remove a Brand

- **Service Layer**
  - Encapsulates business logic and communicates with the repository

- **Repository**
  - `BrandRepository` extends `JpaRepository`

- **Validation**
  - Basic validation annotations on `BrandRequest`

- **Tests**
  - Basic integration tests for controller endpoints

---

## 🎯 Related Issue

Closes #52 
